### PR TITLE
examples/lvgldemo: Select default demo

### DIFF
--- a/examples/lvgldemo/lvgldemo.c
+++ b/examples/lvgldemo/lvgldemo.c
@@ -171,14 +171,27 @@ static demo_create_func_t find_demo_create_func(FAR const char *name)
 int main(int argc, FAR char *argv[])
 {
   demo_create_func_t demo_create_func;
+  FAR const char *demo = NULL;
+  const int func_key_pair_len = sizeof(func_key_pair) /
+                                sizeof(func_key_pair[0]);
 
-  if (argc != 2)
+  /* If no arguments are specified and only 1 demo exists, select the demo */
+
+  if (argc == 1 && func_key_pair_len == 2)  /* 2 because of NULL sentinel */
+    {
+      demo = func_key_pair[0].name;
+    }
+  else if (argc != 2)
     {
       show_usage();
       return EXIT_FAILURE;
     }
+  else
+    {
+      demo = argv[1];
+    }
 
-  demo_create_func = find_demo_create_func(argv[1]);
+  demo_create_func = find_demo_create_func(demo);
 
   if (demo_create_func == NULL)
     {


### PR DESCRIPTION
## Summary

The LVGL Example App `lvgldemo` currently requires 1 argument: the name of the demo to show.

```bash
lvgldemo widgets
```

In this PR, we propose to make the argument optional if there is only one demo configured. This will enable PINE64 PinePhone to boot straight into `lvgldemo` and auto-start the LVGL App, without entering any `nsh` commands.

### Modified Files

`examples/lvgldemo/lvgldemo.c`: If no arguments are specified and only 1 demo exists, select the demo

## Impact

With this PR, `lvgldemo` will no longer require an argument if there is only one demo configured. So this command:

```bash
lvgldemo
```

Is equivalent to `lvgldemo widgets` if there is only one demo `widgets` configured.

If there is more than one demo configured, or if an argument is provided, `lvgldemo` will work the same way as before.

## Testing

We successfully tested `lvgldemo` with a Single Configured Demo:

```bash
lvgldemo
  [Shows Widgets Demo]
lvgldemo widgets
  [Shows Widgets Demo]
```

[(See the Test Log)](https://gist.github.com/lupyuen/b01b325d91c9ad72a0ec88e057e982a8)

And we tested `lvgldemo` with Multiple Configured Demos:

```bash
lvgldemo
  [Shows List of Configured Demos and exits]
lvgldemo music
  [Shows Music Demo]
lvgldemo stress
  [Shows Stress Demo]
```

[(See the Test Log)](https://gist.github.com/lupyuen/b96ed96db295334db1cfabf461efad83)

Also we verified that PinePhone boots successfully to the `lvgldemo widgets` demo automatically, without entering any `nsh` commands. We configured the PinePhone build as follows:

```bash
tools/configure.sh pinephone:lvgl
make menuconfig
```

1. RTOS Features > Tasks and Scheduling

   -  Set "Application entry point" to `lvgldemo_main`

      (INIT_ENTRYPOINT)

   - Set "Application entry name" to `lvgldemo_main`

     (INIT_ENTRYNAME)

2. Application Configuration > NSH Library

    - Disable "Have architecture-specific initialization"

      (NSH_ARCHINIT)
