### PR TITLE
config.nims: Support Nim Apps for RISC-V 32-bit and 64-bit

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -27,6 +27,7 @@ switch "mm", "orc"
 switch "arm.nuttx.gcc.exe", "arm-none-eabi-gcc"
 switch "arm64.nuttx.gcc.exe", "aarch64-none-elf-gcc"
 switch "riscv32.nuttx.gcc.exe", "riscv64-unknown-elf-gcc"
+switch "riscv64.nuttx.gcc.exe", "riscv64-unknown-elf-gcc"
 switch "amd64.nuttx.gcc.exe", "x86_64-linux-gnu-gcc"
 
 switch "nimcache", ".nimcache"
@@ -69,14 +70,19 @@ proc read_config(cfg: string): DotConfig =
       case arch
       of "arm", "arm64":
         result.arch = arch
-      of "riscv":
-        result.arch = "riscv32"
       of "sim":
         if defined(amd64):
           result.arch = "amd64"
         elif defined(aarch64):
           result.arch = "arm64"
         result.isSim = true
+    of "ARCH_FAMILY":
+      let arch = keyval[1].strip(chars = {'"'})
+      case arch
+      of "rv32":
+        result.arch = "riscv32"
+      of "rv64":
+        result.arch = "riscv64"
     of "DEBUG_NOOPT":
       result.opt = oNone
     of "DEBUG_FULLOPT":


### PR DESCRIPTION
## Summary

NuttX Build fails when it compiles `examples/hello_nim` for RISC-V (32-bit and 64-bit). That's because the Nim Config Script `config.nims` couldn't identify the Nim Target Platform: `riscv32` or `riscv64`.

This PR fixes `config.nims` so that Nim Compiler correctly derives the Nim Target Platform (`riscv32` or `riscv64`), by searching NuttX `.config` for `CONFIG_ARCH_FAMILY=rv32` or `rv64`.

This logic is slightly different from the Nim Targets `arm` and `arm64`, which are currently derived from `CONFIG_ARCH=arm` and `arm64`.

`config.nims` is explained in [this article](https://lupyuen.github.io/articles/nim#inside-nim-on-nuttx).

## Impact

With this PR, Nim Apps will build correctly for 32-bit and 64-bit RISC-V.

There is no impact on other platforms, like Arm and Arm64.

## Testing

We tested by building QEMU NuttX with `examples/hello_nim` enabled for RISC-V 32-bit, RISC-V 64-bit and Arm64 (for regression testing).

### RISC-V 32-bit

__Before Fixing:__ NuttX Build fails for `hello_nim` because `arch` and `cpu` in Nim Compiler are empty:

```bash
$ tools/configure.sh rv-virt:nsh
$ kconfig-tweak --enable CONFIG_EXAMPLES_HELLO_NIM
$ make
* arch:    
/workspaces/bookworm/apps/config.nims(1, 2)
Error: argument for command line option expected: '--cpu'
```

[(Failed Build Log for 32-bit RISC-V)](https://gist.github.com/lupyuen/f8ec5996744eb0cea599bbcdc62315a3)

__After Fixing:__ NuttX Build succeeds with the correct `arch` and `cpu` in Nim Compiler:

```bash
$ make
* arch:    riscv32
Hint: used config file '/workspaces/bookworm/apps/config.nims' [Conf]
```

[(Fixed Build Log for 32-bit RISC-V)](https://gist.github.com/lupyuen/c526548fa32ce34eed10b82b49a5c66a)

### RISC-V 64-bit

NuttX Build succeeds with the correct `arch` and `cpu` in Nim Compiler:

```bash
$ tools/configure.sh rv-virt:nsh64
$ kconfig-tweak --enable CONFIG_EXAMPLES_HELLO_NIM
$ make
* arch:    riscv64
Hint: used config file '/workspaces/bookworm/apps/config.nims' [Conf]
```

[(Fixed Build Log for 64-bit RISC-V)](https://gist.github.com/lupyuen/e6ad936c2a85d85d8a666ae506472645)

### Arm64

For Regression Testing: NuttX Build succeeds with the correct `arch` and `cpu` in Nim Compiler:

```bash
$ tools/configure.sh qemu-armv8a:nsh
$ kconfig-tweak --enable CONFIG_EXAMPLES_HELLO_NIM
$ make
* arch:    arm64
Hint: used config file '/workspaces/bookworm/apps/config.nims' [Conf]
```

[(Build Log for Arm64)](https://gist.github.com/lupyuen/503687c6b8d1ed523ea917f527eae5cd)

### Nim Exception

__For Arm64:__ `hello_nim` runs correctly on Arm64 QEMU:

```text
nsh> hello_nim
Hello from task 1! loops: 0
Hello from task 2! loops: 0
...
Hello from task 3! loops: 2
```

[(NuttX Log for Arm64)](https://gist.github.com/lupyuen/503687c6b8d1ed523ea917f527eae5cd#file-nuttx-nim-arm64-log-L49-L107)

__For RISC-V 32-bit and 64-bit:__ `hello_nim` halts with a Load Access Fault for 32-bit RISC-V:

```text
nsh> hello_nim
Hello from task 1! loops: 0
riscv_exception: EXCEPTION: Load access fault. MCAUSE: 00000005, EPC: 8000dd10, MTVAL: 00000038

Load Access Fault at nuttx/fs/inode/fs_files.c:607
  /* if f_inode is NULL, fd was closed */
  if ((*filep)->f_inode == NULL)
8000dd10:	451c                	lw	a5,8(a0)
```

[(NuttX Exception for 32-bit RISC-V)](https://gist.github.com/lupyuen/c526548fa32ce34eed10b82b49a5c66a#file-nuttx-nim-riscv32a-log-L55-L176)

`hello_nim` also halts with a Load Access Fault for 64-bit RISC-V:

```text
nsh> hello_nim
Hello from task 1! loops: 0
riscv_exception: EXCEPTION: Load access fault. MCAUSE: 0000000000000005, EPC: 0000000080002432, MTVAL: d0ef000555638482

Load Access Fault at nuttx/sched/semaphore/sem_wait.c:93
nxsem_wait():
  /* Make sure we were supplied with a valid semaphore. */
  /* Check if the lock is available */
  if (sem->semcount > 0)
    80002432:	00055783          	lhu	a5,0(a0)
```

[(NuttX Exception for 64-bit RISC-V)](https://gist.github.com/lupyuen/e6ad936c2a85d85d8a666ae506472645#file-nuttx-nim-riscv64a-log-L59-L178)

This will be fixed later. For now, we tested a Simple Nim Function that runs correctly on 32-bit and 64-bit RISC-V:

```bash
## Simple Nim Function that prints something
$ cat ../apps/examples/hello_nim/hello_nim_async.nim
proc hello_nim() {.exportc, cdecl.} =
  echo "Hello Nim!"
  GC_runOrc()

$ make
$ qemu-system-riscv32 \
  -M virt,aclint=on \
  -cpu rv32 \
  -smp 8 \
  -bios none \
  -kernel nuttx \
  -nographic

NuttShell (NSH) NuttX-12.0.3
nsh> hello_nim
Hello Nim!
```

[(Simple Nim Log for 32-bit RISC-V)](https://gist.github.com/lupyuen/31420bf5f413cd2a98b7b6c7f3efa476)

[(Simple Nim Log for 64-bit RISC-V)](https://gist.github.com/lupyuen/7cbae7345ce03975c87f61dc10fe652b)
